### PR TITLE
fix for "type" attribute not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,9 +252,7 @@ AFRAME.registerComponent('particle-system', {
             maxAge: {
                 value: settings.maxAge
             },
-            type: {
-                value: settings.type
-            },
+            type: settings.type,
             position: {
                 spread: new THREE.Vector3(settings.positionSpread.x, settings.positionSpread.y, settings.positionSpread.z),
                 randomize: settings.randomize


### PR DESCRIPTION
The type attribute is just a number, it didn't need the {value: ...} wrapper.