### PR TITLE
Added startParticles and stopParticles functions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ This component exposes only a subset of the [ShaderParticleEngine API](http://sq
 <a-entity position="0 2.25 -15" particle-system="preset: dust; texture: ./images/star2.png; color: #0000FF,#00FF00,#FF0000"></a-entity>
 ```
 
+### Functions
+
+#### startParticles
+Enables the emitters. Useful to start the animations when `enabled` is set to `false`.
+
+#### stopParticles
+Disables the emitters.
+
+### Usage
+```javascript
+this.el.components['particle-system'].startParticles();
+this.el.components['particle-system'].stopParticles();
+```
+
 ### Browser Installation
 
 Install and use by directly including the [browser files](dist).


### PR DESCRIPTION
I'm currently working on a small game where I'm using this system for explosions when enemies are defeated. Unfortunately, I noticed that the framerate had some issues and whenever I played on the Oculus Quest, it would crash after about a minute. 

After some investigation, I found out that this was due to the `particle-system`. When I noticed that the `update` function created a new particle group, I assumed that was the cause. When I saw the `startParticles` and `stopParticles` functions, I started calling those instead of changing the `enabled` attribute. This resulted in not only the crashes going away, but the framerate issues were also instantly fixed.

There might be a different way to fix this(like checking if only enabled was changed or adding events of some kind?), but I thought that a quick-fix might be to document these two functions in the README.md, so that other developers may also be aware of this. 

You may want to change the wording a bit(English isn't my native language), but I mostly thought about giving you guys a heads-up.