### PR TITLE
provide default fogColor value for THREE to .copy() over

### DIFF
--- a/lib/SPE.js
+++ b/lib/SPE.js
@@ -1921,7 +1921,7 @@ SPE.Group = function( options ) {
         },
         fogColor: {
             type: 'c',
-            value: null
+            value: new THREE.Color()
         },
         fogNear: {
             type: 'f',


### PR DESCRIPTION
THREE changed how color uniforms are updated from an assignment to a .copy():

https://github.com/mrdoob/three.js/commit/2f350889c9a3d6696f08006db30c35eeb16c6a9d

This means that a default value must be provided for it to be updated properly.

This should resolve at least parts of https://github.com/IdeaSpaceVR/aframe-particle-system-component/issues/55